### PR TITLE
Add wanted rules and delete unwanted rules

### DIFF
--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -116,7 +116,7 @@ func removePublicIPAddress(logger logr.Logger, openstackClientFactory openstackc
 }
 
 func removeSecurityGroup(openstackClientFactory openstackclient.Factory, opt *Options) error {
-	bastionSecurityGroups, err := getSecurityGroupId(openstackClientFactory, opt.SecurityGroup)
+	bastionSecurityGroups, err := getSecurityGroups(openstackClientFactory, opt.SecurityGroup)
 	if err != nil {
 		return err
 	}

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -119,23 +119,6 @@ func (c *NetworkingClient) ListRules(listOpts rules.ListOpts) ([]rules.SecGroupR
 	return rules.ExtractRules(allPages)
 }
 
-// GetRulesByName returns rule info by rule name
-func (c *NetworkingClient) GetRulesByName(name, secGroupID string) ([]rules.SecGroupRule, error) {
-	listOpts := rules.ListOpts{
-		Description: name,
-		SecGroupID:  secGroupID,
-	}
-	return c.ListRules(listOpts)
-}
-
-// GetRulesBySecurityGroupID returns rule info by rule name
-func (c *NetworkingClient) GetRulesBySecurityGroupID(secGroupID string) ([]rules.SecGroupRule, error) {
-	listOpts := rules.ListOpts{
-		SecGroupID: secGroupID,
-	}
-	return c.ListRules(listOpts)
-}
-
 // CreateRule create security group rule
 func (c *NetworkingClient) CreateRule(createOpts rules.CreateOpts) (*rules.SecGroupRule, error) {
 	return rules.Create(c.client, createOpts).Extract()

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -113,8 +113,6 @@ type Networking interface {
 	// Security Group rules
 	CreateRule(createOpts rules.CreateOpts) (*rules.SecGroupRule, error)
 	ListRules(listOpts rules.ListOpts) ([]rules.SecGroupRule, error)
-	GetRulesByName(name, secGroupID string) ([]rules.SecGroupRule, error)
-	GetRulesBySecurityGroupID(secGroupID string) ([]rules.SecGroupRule, error)
 	DeleteRule(ruleID string) error
 }
 


### PR DESCRIPTION
this PR is the implementation of my suggestion https://github.com/gardener/gardener-extension-provider-openstack/pull/365#discussion_r794588984
> ALWAYS reconcile the rules which means:
> 
> Get all rules of the bastion security group to check for wanted and unwanted rules
> add wanted rules (if not already there)
> AFTERWARDS remove unwanted rules (except there is a way to apply all at once)

It would be good if you would add some tests, in particular for the `rulesSymmetricDifference` and `ruleEqual` functions.